### PR TITLE
Add wiring instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
    ```bash
    pip install Adafruit_DHT
    ```
-2. 将 DHT22 数据引脚连接到 GPIO4（可在 `main.py` 中指定），并连接电源与地线。
+2. 将 DHT22 按以下方式连接至树莓派：
+   - VCC 接 3.3V（例如针脚 1）
+   - GND 接 GND（例如针脚 6）
+   - DATA 接 GPIO4（针脚 7，可在 `main.py` 中更改）
+   - 若使用裸传感器，需要在 VCC 与 DATA 之间串联约 10kΩ 的上拉电阻（部分模块已内置）
 
 ## 运行脚本
 运行脚本（持续读取）：


### PR DESCRIPTION
## Summary
- clarify how to wire the DHT22 sensor to the Raspberry Pi 5

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686f7ebed9e48331a8a4903a0f784077